### PR TITLE
Attempt two at running `actions/setup-node` as part of a composite action.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,10 +17,6 @@ jobs:
       - name: Prepare NodeJS
         id: prepare-nodejs
         uses: ./
-      - name: Setup NodeJS
-        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561
-        with:
-          node-version: ${{ steps.prepare-nodejs.outputs.node-version }}
       - name: Install Dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,6 @@ jobs:
       - name: Prepare NodeJS
         id: prepare-nodejs
         uses: ./
-      - name: Setup NodeJS
-        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561
-        with:
-          node-version: ${{ steps.prepare-nodejs.outputs.node-version }}
       - name: Install Dependencies
         run: npm ci
       - name: Create the Release

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,19 @@
-name: Build JavaScript Action Action
+name: NodeJS Prepare Action
 description: A GitHub Action for setting up useful stuff in NodeJS workflows.
 runs:
-  using: node12
-  main: ./bootstrap-shim.js
-  post: ./build/post.js
+  using: composite
+  steps:
+    # We cannot reference $GITHUB_ACTION_PATH in the path to other actions, but we can symlink it to a known location and then reference that location.
+    # This ensures that the path to the action stays the same even if the runner starts storing actions in different locations or the action is being run from a fork with a different name.
+    - shell: sh
+      run: ln --symbolic "$GITHUB_ACTION_PATH" "./../_nodejs-prepare-action"
+    - id: prepare-nodejs
+      uses: ./../_nodejs-prepare-action/subactions/prepare/
+      with:
+        node-version-path: ${{ inputs.node-version-path }}
+    - uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458
+      with:
+        node-version: ${{ steps.prepare-nodejs.outputs.node-version }}
 inputs:
   node-version-path:
     description: The path to the `.node-version` file.

--- a/subactions/prepare/action.yml
+++ b/subactions/prepare/action.yml
@@ -1,0 +1,11 @@
+name: NodeJS Prepare Action
+description: A GitHub Action for setting up useful stuff in NodeJS workflows.
+runs:
+  using: node12
+  main: ./../../bootstrap-shim.js
+  post: ./../../build/post.js
+inputs:
+  node-version-path:
+    description: The path to the `.node-version` file.
+    required: true
+    default: ./.node-version


### PR DESCRIPTION
This is hopefully a more successful attempt at using a composite action to include setting up NodeJS. This is done by using a bit of a hack to reference the subaction regardless of where it is stored by symlinking the main action directory to a known relative path.

I'm not a huge fan of this, but it seems like a reasonable compromise given the restrictions on the syntax of Actions.